### PR TITLE
Adding support for external triggers

### DIFF
--- a/cmake/CMakeListsROS2.txt
+++ b/cmake/CMakeListsROS2.txt
@@ -24,8 +24,6 @@ find_package(ament_cmake_ros REQUIRED)
 
 find_package(OpenCV REQUIRED)
 
-find_package(Eigen3 REQUIRED NO_MODULE) 
-
 set(ROS2_DEPENDENCIES
   "rclcpp"
   "rclcpp_components"

--- a/cmake/CMakeListsROS2.txt
+++ b/cmake/CMakeListsROS2.txt
@@ -24,6 +24,8 @@ find_package(ament_cmake_ros REQUIRED)
 
 find_package(OpenCV REQUIRED)
 
+find_package(Eigen3 REQUIRED NO_MODULE) 
+
 set(ROS2_DEPENDENCIES
   "rclcpp"
   "rclcpp_components"

--- a/include/frequency_cam/frequency_cam.h
+++ b/include/frequency_cam/frequency_cam.h
@@ -104,8 +104,8 @@ public:
   void initializeState(uint32_t width, uint32_t height, uint64_t t_first, uint64_t t_off);
 
   // returns frequency image
-  cv::Mat makeFrequencyAndEventImage(
-    cv::Mat * eventImage, bool overlayEvents, bool useLogFrequency, float dt);
+    std::optional<cv::Mat> makeFrequencyAndEventImage(
+    cv::Mat * eventImage, bool overlayEvents, bool useLogFrequency, float dt, uint64_t trigger_timestamp = 0);
 
   void getStatistics(size_t * numEvents) const;
   void resetStatistics();

--- a/include/frequency_cam/frequency_cam.h
+++ b/include/frequency_cam/frequency_cam.h
@@ -265,7 +265,7 @@ private:
           auto x_candidate = std::get<0>(frequency_point.second.at(j));
           auto y_candidate = std::get<1>(frequency_point.second.at(j));
 
-          if ((std::fabs(x - x_candidate) < 70) && (std::fabs(y - y_candidate) < 70)) {
+          if ((std::fabs(x - x_candidate) < 20) && (std::fabs(y - y_candidate) < 20)) {
             candidate_indices.emplace_back(j);
             x_values.emplace_back(x_candidate);
             y_values.emplace_back(y_candidate);
@@ -273,7 +273,7 @@ private:
           }
         }
 
-        if (40 < counts) {
+        if (10 < counts) {
           candidate_indices.emplace_back(i);
           x_values.emplace_back(x);
           y_values.emplace_back(y);

--- a/include/frequency_cam/frequency_cam.h
+++ b/include/frequency_cam/frequency_cam.h
@@ -110,6 +110,10 @@ public:
   void getStatistics(size_t * numEvents) const;
   void resetStatistics();
 
+  void getNrExternalTriggers(size_t * nrExternalTriggers) const;
+
+  void getNrSyncMatches(size_t * nrSyncMatches) const;
+
   void setTriggers(const std::string & triggers_file);
 
 private:

--- a/include/frequency_cam/frequency_cam.h
+++ b/include/frequency_cam/frequency_cam.h
@@ -27,6 +27,7 @@
 #include <optional>
 #include <opencv2/core/core.hpp>
 #include <opencv2/imgproc.hpp>
+#include <eigen3/Eigen/Dense>
 
 // #define DEBUG
 
@@ -331,6 +332,15 @@ private:
 
     // if (!filtered_frequency_points.empty()) {
     if (filtered_frequency_points.size() == 3) {
+
+      // Eigen::Matrix3f matrix;
+      // matrix << std::get<0>(filtered_frequency_points.at(0)), std::get<1>(filtered_frequency_points.at(0)), 1.0,
+      //           std::get<0>(filtered_frequency_points.at(1)), std::get<1>(filtered_frequency_points.at(1)), 1.0,
+      //           std::get<0>(filtered_frequency_points.at(2)), std::get<1>(filtered_frequency_points.at(2)), 1.0;
+      // Eigen::FullPivLU<Eigen::Matrix3f> lu_decomp(matrix);
+      // auto rank = lu_decomp.rank();
+      // std::cout << "Rank: " << rank << std::endl;
+      // // result = rank([x2-x1, y2-y1; x3-x1, y3-y1]) < 2;
     if (!filtered_frequency_points.empty()) {
       std::cout << "Filtered points:" << std::endl;
       std::cout << "time stamp: " << lastEventTime_ << std::endl;

--- a/include/frequency_cam/frequency_cam.h
+++ b/include/frequency_cam/frequency_cam.h
@@ -265,8 +265,7 @@ private:
           const double f = 1.0 / std::max(state.period, decltype(state.period)(1e-6));
           // filter out any pixels that have not been updated recently
           if (dt < maxDt * timeoutCycles_ && dt * f < timeoutCycles_) {
-            auto frequency = std::max(T::tf(f), minFreq);
-            rawImg.at<float>(iy, ix) = frequency;
+            rawImg.at<float>(iy, ix) = std::max(T::tf(f), minFreq);
           } else {
             rawImg.at<float>(iy, ix) = 0;  // mark as invalid
           }

--- a/include/frequency_cam/frequency_cam.h
+++ b/include/frequency_cam/frequency_cam.h
@@ -31,7 +31,7 @@ namespace frequency_cam
 class FrequencyCam : public event_array_codecs::EventProcessor
 {
 public:
-  FrequencyCam() {};
+  FrequencyCam() {}
   ~FrequencyCam();
 
   FrequencyCam(const FrequencyCam &) = delete;

--- a/include/frequency_cam/frequency_cam.h
+++ b/include/frequency_cam/frequency_cam.h
@@ -226,10 +226,12 @@ private:
   cv::Mat makeTransformedFrequencyImage(cv::Mat * eventFrame, float eventImageDt)
   {
     std::map<double, std::vector<std::tuple<int, int>>> frequency_points;
-    const int min_range_1 = 2800;
-    const int max_range_1 = 3200;
-    const int min_range_2 = 3800;
-    const int max_range_2 = 4200;
+    // const int min_range_1 = 2800;
+    // const int max_range_1 = 3200;
+    // const int min_range_2 = 3800;
+    // const int max_range_2 = 4200;
+    const int min_range_2 = 1500;
+    const int max_range_2 = 2500;
     cv::Mat rawImg(height_, width_, CV_32FC1, 0.0);
     const double maxDt = 1.0 / freq_[0] * timeoutCycles_;
     const double minFreq = T::tf(freq_[0]);
@@ -248,7 +250,7 @@ private:
           if (dt < maxDt * timeoutCycles_ && dt * f < timeoutCycles_) {
             auto frequency = std::max(T::tf(f), minFreq);
             if (
-              (frequency > min_range_1 && frequency < max_range_1) ||
+              // (frequency > min_range_1 && frequency < max_range_1) ||
               (frequency > min_range_2 && frequency < max_range_2)) {
               frequency = roundUp(frequency, 500);
               if (1 == frequency_points.count(frequency)) {

--- a/include/frequency_cam/frequency_cam.h
+++ b/include/frequency_cam/frequency_cam.h
@@ -344,15 +344,15 @@ private:
       // auto rank = lu_decomp.rank();
       // std::cout << "Rank: " << rank << std::endl;
       // // result = rank([x2-x1, y2-y1; x3-x1, y3-y1]) < 2;
-    if (!filtered_frequency_points.empty()) {
-      std::cout << "Filtered points:" << std::endl;
-      std::cout << "time stamp: " << lastEventTime_ << std::endl;
+
+      // std::cout << "Filtered points:" << std::endl;
+      // std::cout << "time stamp: " << lastEventTime_ << std::endl;
       //for (const auto & filtered_point : filtered_points) {
       for (std::size_t i = 0; i < filtered_frequency_points.size(); ++i) {
-        std::cout << "x: " << std::get<0>(filtered_frequency_points.at(i))
-                  << ", y: " << std::get<1>(filtered_frequency_points.at(i))
-                  << ", frequency: " << std::get<2>(filtered_frequency_points.at(i))
-                  << ", number of points: " << number_of_points.at(i) << std::endl;
+        // std::cout << "x: " << std::get<0>(filtered_frequency_points.at(i))
+        //           << ", y: " << std::get<1>(filtered_frequency_points.at(i))
+        //           << ", frequency: " << std::get<2>(filtered_frequency_points.at(i))
+        //           << ", number of points: " << number_of_points.at(i) << std::endl;
         csv_file_ << lastEventTime_ << "," << std::get<0>(filtered_frequency_points.at(i)) << ","
                   << std::get<1>(filtered_frequency_points.at(i)) << ","
                   << std::get<2>(filtered_frequency_points.at(i)) << "\n";

--- a/include/frequency_cam/frequency_cam.h
+++ b/include/frequency_cam/frequency_cam.h
@@ -48,10 +48,11 @@ public:
   // ------------- inherited from EventProcessor
   inline void eventCD(uint64_t sensor_time, uint16_t ex, uint16_t ey, uint8_t polarity) override
   {
-    // std::cout << "Event: sensor_time: " << sensor_time << std::endl;
+    // std::cout << "Event: time stamp: " << sensor_time << std::endl;
     Event e(shorten_time(sensor_time), ex, ey, polarity);
     updateState(&state_[e.y * width_ + e.x], e);
     lastEventTime_ = e.t;
+    lastEventTimeNs_ = sensor_time;
     eventCount_++;
     eventTimesNs_.emplace_back(sensor_time);
   }
@@ -92,6 +93,8 @@ public:
 
   void getStatistics(size_t * numEvents) const;
   void resetStatistics();
+
+  void setTriggers(const std::string & triggers_file);
 
 private:
   struct Event  // event representation for convenience
@@ -359,6 +362,8 @@ private:
            std::get<1>(filtered_frequency_points.at(i))},
           2, CV_RGB(4500, 4500, 4500), 4);
       }
+
+      nrDetectedWands_++;
     }
 
     return (rawImg);
@@ -396,10 +401,13 @@ private:
   uint64_t sensor_time_;
   bool eventExtTriggerInitialized_{false};
   std::size_t nrExtTriggers_{0};
-  std::size_t nrMatches_{0};
+  std::size_t nrSyncMatches_{0};
+  std::size_t nrDetectedWands_{0};
   uint8_t lasteExternalEdge_;
 
   std::ofstream csv_file_;
+  std::vector<uint64_t> externalTriggers_;
+  uint64_t lastEventTimeNs_;
 };
 std::ostream & operator<<(std::ostream & os, const FrequencyCam::Event & e);
 }  // namespace frequency_cam

--- a/include/frequency_cam/frequency_cam.h
+++ b/include/frequency_cam/frequency_cam.h
@@ -329,6 +329,8 @@ private:
       }
     }
 
+    // if (!filtered_frequency_points.empty()) {
+    if (filtered_frequency_points.size() == 3) {
     if (!filtered_frequency_points.empty()) {
       std::cout << "Filtered points:" << std::endl;
       std::cout << "time stamp: " << lastEventTime_ << std::endl;

--- a/include/frequency_cam/frequency_cam.h
+++ b/include/frequency_cam/frequency_cam.h
@@ -39,10 +39,7 @@ int roundUp(const int numToRound, const int multiple);
 class FrequencyCam : public event_array_codecs::EventProcessor
 {
 public:
-  FrequencyCam(const bool use_external_triggers = false,
-               const uint64_t max_time_difference_to_trigger_ = 0)
-  : use_external_triggers_{use_external_triggers},
-    max_time_difference_to_trigger_{max_time_difference_to_trigger} {}
+  FrequencyCam() = default;
   ~FrequencyCam();
 
   FrequencyCam(const FrequencyCam &) = delete;
@@ -108,12 +105,13 @@ public:
 
   bool initialize(
     double minFreq, double maxFreq, double cutoffPeriod, int timeoutCycles, uint16_t debugX,
-    uint16_t debugY);
+    uint16_t debugY, const bool use_external_triggers = false,
+    const uint64_t max_time_difference_us_to_trigger = 0);
 
   void initializeState(uint32_t width, uint32_t height, uint64_t t_first, uint64_t t_off);
 
   // returns frequency image
-  std::optional<cv::Mat> makeFrequencyAndEventImage(
+  std::optional<std::vector<cv::Mat>> makeFrequencyAndEventImage(
     cv::Mat * eventImage, bool overlayEvents, bool useLogFrequency, float dt);
 
   void getStatistics(size_t * numEvents) const;
@@ -324,7 +322,7 @@ private:
   bool fix_time_stamps_{false}; 
 
   bool use_external_triggers_;
-  uint64_t max_time_difference_to_trigger_;
+  uint64_t max_time_difference_us_to_trigger_;
 };
 std::ostream & operator<<(std::ostream & os, const FrequencyCam::Event & e);
 }  // namespace frequency_cam

--- a/include/frequency_cam/frequency_cam.h
+++ b/include/frequency_cam/frequency_cam.h
@@ -104,7 +104,7 @@ public:
   void initializeState(uint32_t width, uint32_t height, uint64_t t_first, uint64_t t_off);
 
   // returns frequency image
-  std::optional<std::vector<cv::Mat>> makeFrequencyAndEventImage(
+  cv::Mat makeFrequencyAndEventImage(
     cv::Mat * eventImage, bool overlayEvents, bool useLogFrequency, float dt);
 
   void getStatistics(size_t * numEvents) const;
@@ -113,8 +113,6 @@ public:
   void getNrExternalTriggers(size_t * nrExternalTriggers) const;
 
   void getNrSyncMatches(size_t * nrSyncMatches) const;
-
-  void setTriggers(const std::string & triggers_file);
 
 private:
   struct Event  // event representation for convenience

--- a/include/frequency_cam/frequency_cam.h
+++ b/include/frequency_cam/frequency_cam.h
@@ -243,12 +243,10 @@ private:
       }
     }
 
-    std::vector<std::tuple<int, int>> filtered_points;
+    std::vector<std::tuple<int, int, int>> filtered_frequency_points;
+    std::vector<std::size_t> number_of_points;
     //for (const auto& [key, value] : points) {
     for (const auto & frequency_point : frequency_points) {
-      //   std::cout << '[' << key << "] = " << value << "; ";
-      std::cout << "point: " << frequency_point.first << std::endl;
-
       std::vector<std::size_t> assigned_indices;
       //for (const auto& point : frequency_point.second) {
       for (std::size_t i = 0; i < frequency_point.second.size(); ++i) {
@@ -289,7 +287,7 @@ private:
           mean_y /= y_values.size();
 
           bool insert = true;
-          for (const auto& point : filtered_points) {
+          for (const auto & point : filtered_frequency_points) {
             x = std::get<0>(point);
             y = std::get<1>(point);
 
@@ -299,7 +297,8 @@ private:
             }
           }
           if (insert) {
-            filtered_points.emplace_back(mean_x, mean_y);
+            filtered_frequency_points.emplace_back(mean_x, mean_y, frequency_point.first);
+            number_of_points.emplace_back(x_values.size());
           }
 
           assigned_indices.insert(
@@ -309,9 +308,13 @@ private:
     }
 
     std::cout << "Filtered points:" << std::endl;
-    for (const auto & filtered_point : filtered_points) {
-      std::cout << "x: " << std::get<0>(filtered_point) << ", y: " << std::get<1>(filtered_point)
-                << std::endl;
+    std::cout << "time stamp: " << lastEventTime_ << std::endl;
+    //for (const auto & filtered_point : filtered_points) {
+    for (std::size_t i = 0; i < filtered_frequency_points.size(); ++i) {
+      std::cout << "x: " << std::get<0>(filtered_frequency_points.at(i))
+                << ", y: " << std::get<1>(filtered_frequency_points.at(i))
+                << ", frequency: " << std::get<2>(filtered_frequency_points.at(i))
+                << ", number of points: " << number_of_points.at(i) << std::endl;
     }
 
     return (rawImg);

--- a/include/frequency_cam/frequency_cam.h
+++ b/include/frequency_cam/frequency_cam.h
@@ -35,7 +35,11 @@ int roundUp(const int numToRound, const int multiple);
 class FrequencyCam : public event_array_codecs::EventProcessor
 {
 public:
-  FrequencyCam() {}
+  FrequencyCam()
+  {
+    csv_file_.open("frequency_points.csv");
+    csv_file_ << "timestamp,x,y,frequency.\n";
+  }
   ~FrequencyCam();
 
   FrequencyCam(const FrequencyCam &) = delete;
@@ -315,6 +319,9 @@ private:
                 << ", y: " << std::get<1>(filtered_frequency_points.at(i))
                 << ", frequency: " << std::get<2>(filtered_frequency_points.at(i))
                 << ", number of points: " << number_of_points.at(i) << std::endl;
+      csv_file_ << std::to_string(lastEventTime_) << "," << std::get<0>(filtered_frequency_points.at(i)) << ","
+                << std::get<1>(filtered_frequency_points.at(i))
+                << "," std::get<1>(filtered_frequency_points.at(i)) << \n ";
     }
 
     return (rawImg);
@@ -347,6 +354,8 @@ private:
   uint16_t debugX_{0};
   uint16_t debugY_{0};
   uint64_t timeOffset_{0};
+
+  std::ofstream csv_file_;
 };
 std::ostream & operator<<(std::ostream & os, const FrequencyCam::Event & e);
 }  // namespace frequency_cam

--- a/include/frequency_cam/frequency_cam.h
+++ b/include/frequency_cam/frequency_cam.h
@@ -309,7 +309,6 @@ private:
   bool eventExtTriggerInitialized_{false};
   std::size_t nrExtTriggers_{0};
   std::size_t nrSyncMatches_{0};
-  std::size_t nrDetectedWands_{0};
   uint8_t lastExternalEdge_;
 
   std::vector<uint64_t> externalTriggers_;

--- a/include/frequency_cam/frequency_cam.h
+++ b/include/frequency_cam/frequency_cam.h
@@ -74,7 +74,7 @@ public:
       }
       lasteExternalEdge_ = edge;
     }
-    // std::cout << "External trigger: sensor_time: " << sensor_time << ", edge: " << std::to_string(edge) << ", id: " << std::to_string(id) << std::endl;
+    // std::cout << "External trigger: sensor_time: " << sensor_time << ", edge: " << std::to_string(edge) << std::endl;
   }
 
   void finished() override {}

--- a/include/frequency_cam/frequency_cam.h
+++ b/include/frequency_cam/frequency_cam.h
@@ -35,11 +35,7 @@ int roundUp(const int numToRound, const int multiple);
 class FrequencyCam : public event_array_codecs::EventProcessor
 {
 public:
-  FrequencyCam()
-  {
-    csv_file_.open("frequency_points.csv");
-    csv_file_ << "timestamp,x,y,frequency.\n";
-  }
+  FrequencyCam() : csv_file_("frequency_points.csv") { csv_file_ << "timestamp,x,y,frequency.\n"; }
   ~FrequencyCam();
 
   FrequencyCam(const FrequencyCam &) = delete;
@@ -66,7 +62,7 @@ public:
 
   // returns frequency image
   cv::Mat makeFrequencyAndEventImage(
-    cv::Mat * eventImage, bool overlayEvents, bool useLogFrequency, float dt) const;
+    cv::Mat * eventImage, bool overlayEvents, bool useLogFrequency, float dt);
 
   void getStatistics(size_t * numEvents) const;
   void resetStatistics();
@@ -202,7 +198,7 @@ private:
   };
 
   template <class T, class U>
-  cv::Mat makeTransformedFrequencyImage(cv::Mat * eventFrame, float eventImageDt) const
+  cv::Mat makeTransformedFrequencyImage(cv::Mat * eventFrame, float eventImageDt)
   {
     std::vector<std::tuple<int, int, int>> freq_1;
     std::map<double, std::vector<std::tuple<int, int>>> frequency_points;
@@ -311,17 +307,19 @@ private:
       }
     }
 
-    std::cout << "Filtered points:" << std::endl;
-    std::cout << "time stamp: " << lastEventTime_ << std::endl;
-    //for (const auto & filtered_point : filtered_points) {
-    for (std::size_t i = 0; i < filtered_frequency_points.size(); ++i) {
-      std::cout << "x: " << std::get<0>(filtered_frequency_points.at(i))
-                << ", y: " << std::get<1>(filtered_frequency_points.at(i))
-                << ", frequency: " << std::get<2>(filtered_frequency_points.at(i))
-                << ", number of points: " << number_of_points.at(i) << std::endl;
-      csv_file_ << std::to_string(lastEventTime_) << "," << std::get<0>(filtered_frequency_points.at(i)) << ","
-                << std::get<1>(filtered_frequency_points.at(i))
-                << "," std::get<1>(filtered_frequency_points.at(i)) << \n ";
+    if (!filtered_frequency_points.empty()) {
+      std::cout << "Filtered points:" << std::endl;
+      std::cout << "time stamp: " << lastEventTime_ << std::endl;
+      //for (const auto & filtered_point : filtered_points) {
+      for (std::size_t i = 0; i < filtered_frequency_points.size(); ++i) {
+        std::cout << "x: " << std::get<0>(filtered_frequency_points.at(i))
+                  << ", y: " << std::get<1>(filtered_frequency_points.at(i))
+                  << ", frequency: " << std::get<2>(filtered_frequency_points.at(i))
+                  << ", number of points: " << number_of_points.at(i) << std::endl;
+        csv_file_ << lastEventTime_ << "," << std::get<0>(filtered_frequency_points.at(i)) << ","
+                  << std::get<1>(filtered_frequency_points.at(i)) << ","
+                  << std::get<2>(filtered_frequency_points.at(i)) << "\n";
+      }
     }
 
     return (rawImg);

--- a/include/frequency_cam/frequency_cam.h
+++ b/include/frequency_cam/frequency_cam.h
@@ -247,7 +247,7 @@ private:
   };
 
   template <class T, class U>
-  cv::Mat makeTransformedFrequencyImage(cv::Mat * eventFrame, float eventImageDt)
+  cv::Mat makeTransformedFrequencyImage(cv::Mat * eventFrame, float eventImageDt) const
   {
     cv::Mat rawImg(height_, width_, CV_32FC1, 0.0);
     const double maxDt = 1.0 / freq_[0] * timeoutCycles_;

--- a/include/frequency_cam/frequency_cam.h
+++ b/include/frequency_cam/frequency_cam.h
@@ -201,7 +201,6 @@ private:
   template <class T, class U>
   cv::Mat makeTransformedFrequencyImage(cv::Mat * eventFrame, float eventImageDt)
   {
-    std::vector<std::tuple<int, int, int>> freq_1;
     std::map<double, std::vector<std::tuple<int, int>>> frequency_points;
     const int min_range_1 = 2800;
     const int max_range_1 = 3200;
@@ -227,7 +226,6 @@ private:
             if (
               (frequency > min_range_1 && frequency < max_range_1) ||
               (frequency > min_range_2 && frequency < max_range_2)) {
-              freq_1.emplace_back(ix, iy, frequency);
               frequency = roundUp(frequency, 500);
               if (1 == frequency_points.count(frequency)) {
                 frequency_points[frequency].emplace_back(ix, iy);
@@ -246,10 +244,8 @@ private:
 
     std::vector<std::tuple<int, int, int>> filtered_frequency_points;
     std::vector<std::size_t> number_of_points;
-    //for (const auto& [key, value] : points) {
     for (const auto & frequency_point : frequency_points) {
       std::vector<std::size_t> assigned_indices;
-      //for (const auto& point : frequency_point.second) {
       for (std::size_t i = 0; i < frequency_point.second.size(); ++i) {
         if (std::count(assigned_indices.begin(), assigned_indices.end(), i)) {
           continue;
@@ -262,7 +258,6 @@ private:
         auto y = std::get<1>(frequency_point.second.at(i));
 
         std::size_t counts = 0;
-        // for (const auto& point_candidate : frequency_point.second) {
         for (std::size_t j = i + 1; j < frequency_point.second.size(); ++j) {
           if (std::count(assigned_indices.begin(), assigned_indices.end(), j)) {
             continue;

--- a/include/frequency_cam/frequency_cam.h
+++ b/include/frequency_cam/frequency_cam.h
@@ -353,7 +353,7 @@ private:
         //           << ", y: " << std::get<1>(filtered_frequency_points.at(i))
         //           << ", frequency: " << std::get<2>(filtered_frequency_points.at(i))
         //           << ", number of points: " << number_of_points.at(i) << std::endl;
-        csv_file_ << lastEventTime_ << "," << std::get<0>(filtered_frequency_points.at(i)) << ","
+        csv_file_ << trigger_timestamp << "," << std::get<0>(filtered_frequency_points.at(i)) << ","
                   << std::get<1>(filtered_frequency_points.at(i)) << ","
                   << std::get<2>(filtered_frequency_points.at(i)) << "\n";
         cv::circle(

--- a/include/frequency_cam/frequency_cam.h
+++ b/include/frequency_cam/frequency_cam.h
@@ -18,6 +18,7 @@
 
 #include <event_array_codecs/event_processor.h>
 
+#include <atomic>
 #include <cstdint>
 #include <fstream>
 #include <iostream>
@@ -41,13 +42,13 @@ public:
   inline void eventCD(uint64_t sensor_time, uint16_t ex, uint16_t ey, uint8_t polarity) override
   {
     // If the first time stamp is > 15s, there is an offset which we subtract every time.
-    if (!initialize_time_stamps_) {
-      initialize_time_stamps_ = true;
+    if (!initializeTimeStamps_) {
+      initializeTimeStamps_ = true;
       if (sensor_time > 15000000000) {
-        fix_time_stamps_ = true;
+        fixTimeStamps_ = true;
       }
     }
-    if (fix_time_stamps_) {
+    if (fixTimeStamps_) {
       // Offset taken from:
       // https://docs.prophesee.ai/stable/data/encoding_formats/evt3.html#evt-time-high
       sensor_time -= 16777215000;
@@ -62,13 +63,13 @@ public:
   void eventExtTrigger(uint64_t sensor_time, uint8_t edge, uint8_t /*id*/) override
   {
     // If the first time stamp is > 15s, there is an offset which we subtract every time.
-    if (!initialize_time_stamps_) {
-      initialize_time_stamps_ = true;
+    if (!initializeTimeStamps_) {
+      initializeTimeStamps_ = true;
       if (sensor_time > 15000000000) {
-        fix_time_stamps_ = true;
+        fixTimeStamps_ = true;
       }
     }
-    if (fix_time_stamps_) {
+    if (fixTimeStamps_) {
       // Offset taken from:
       // https://docs.prophesee.ai/stable/data/encoding_formats/evt3.html#evt-time-high
       sensor_time -= 16777215000;
@@ -310,11 +311,11 @@ private:
 
   std::vector<uint64_t> externalTriggers_;
   uint64_t lastEventTimeNs_;
-  bool initialize_time_stamps_{false};
-  bool fix_time_stamps_{false};
+  bool initializeTimeStamps_{false};
+  bool fixTimeStamps_{false};
 
-  bool use_external_triggers_;
-  uint64_t max_time_difference_us_to_trigger_;
+  bool useExternalTriggers_;
+  uint64_t maxTimeDifferenceUsToTrigger_;
 };
 std::ostream & operator<<(std::ostream & os, const FrequencyCam::Event & e);
 }  // namespace frequency_cam

--- a/include/frequency_cam/frequency_cam.h
+++ b/include/frequency_cam/frequency_cam.h
@@ -20,14 +20,14 @@
 
 #include <atomic>
 #include <cstdint>
+#include <eigen3/Eigen/Dense>
 #include <fstream>
 #include <iostream>
 #include <map>
 #include <numeric>
-#include <optional>
 #include <opencv2/core/core.hpp>
 #include <opencv2/imgproc.hpp>
-#include <eigen3/Eigen/Dense>
+#include <optional>
 
 // #define DEBUG
 
@@ -319,7 +319,7 @@ private:
   std::vector<uint64_t> externalTriggers_;
   uint64_t lastEventTimeNs_;
   bool initialize_time_stamps_{false};
-  bool fix_time_stamps_{false}; 
+  bool fix_time_stamps_{false};
 
   bool use_external_triggers_;
   uint64_t max_time_difference_us_to_trigger_;

--- a/include/frequency_cam/frequency_cam.h
+++ b/include/frequency_cam/frequency_cam.h
@@ -18,28 +18,20 @@
 
 #include <event_array_codecs/event_processor.h>
 
-#include <atomic>
 #include <cstdint>
-#include <eigen3/Eigen/Dense>
 #include <fstream>
 #include <iostream>
-#include <map>
-#include <numeric>
 #include <opencv2/core/core.hpp>
-#include <opencv2/imgproc.hpp>
 #include <optional>
 
 // #define DEBUG
 
 namespace frequency_cam
 {
-
-int roundUp(const int numToRound, const int multiple);
-
 class FrequencyCam : public event_array_codecs::EventProcessor
 {
 public:
-  FrequencyCam() = default;
+  FrequencyCam() {};
   ~FrequencyCam();
 
   FrequencyCam(const FrequencyCam &) = delete;

--- a/include/frequency_cam/frequency_cam.h
+++ b/include/frequency_cam/frequency_cam.h
@@ -24,6 +24,7 @@
 #include <map>
 #include <numeric>
 #include <opencv2/core/core.hpp>
+#include <opencv2/imgproc.hpp>
 
 // #define DEBUG
 
@@ -319,6 +320,11 @@ private:
         csv_file_ << lastEventTime_ << "," << std::get<0>(filtered_frequency_points.at(i)) << ","
                   << std::get<1>(filtered_frequency_points.at(i)) << ","
                   << std::get<2>(filtered_frequency_points.at(i)) << "\n";
+        cv::circle(
+          rawImg,
+          {std::get<0>(filtered_frequency_points.at(i)),
+           std::get<1>(filtered_frequency_points.at(i))},
+          2, CV_RGB(4500, 4500, 4500), 4);
       }
     }
 

--- a/include/frequency_cam/frequency_cam_ros2.h
+++ b/include/frequency_cam/frequency_cam_ros2.h
@@ -60,6 +60,7 @@ private:
   bool useLogFrequency_{false};
   FrequencyCam cam_;
   ImageMaker imageMaker_;
+  bool use_external_triggers_;
   // --- statistics
   uint64_t totTime_{0};
   uint64_t msgCount_{0};

--- a/include/frequency_cam/frequency_cam_ros2.h
+++ b/include/frequency_cam/frequency_cam_ros2.h
@@ -42,8 +42,10 @@ private:
   void frameTimerExpired();
   void statisticsTimerExpired();
   bool initialize();
+  void setTriggers(const std::string & triggers_file);
   void eventMsg(const EventArray::ConstSharedPtr msg);
-  void playEventsFromBag(const std::string & bagName, const std::string & bagTopic, const std::string & trigger_file);
+  void playEventsFromBag(const std::string & bagName, const std::string & bagTopic);
+  void playEventsFromBagFrameBased(const std::string & bagName, const std::string & bagTopic, const std::string & triggers_file);
   // ------ variables ----
   rclcpp::Time lastPubTime_{0};
   rclcpp::Subscription<EventArray>::SharedPtr eventSub_;
@@ -61,6 +63,7 @@ private:
   FrequencyCam cam_;
   ImageMaker imageMaker_;
   bool use_external_triggers_;
+  std::vector<uint64_t> externalTriggers_;
   // --- statistics
   uint64_t totTime_{0};
   uint64_t msgCount_{0};

--- a/include/frequency_cam/frequency_cam_ros2.h
+++ b/include/frequency_cam/frequency_cam_ros2.h
@@ -43,7 +43,7 @@ private:
   void statisticsTimerExpired();
   bool initialize();
   void eventMsg(const EventArray::ConstSharedPtr msg);
-  void playEventsFromBag(const std::string & bagName, const std::string & bagTopic);
+  void playEventsFromBag(const std::string & bagName, const std::string & bagTopic, const std::string & trigger_file);
   // ------ variables ----
   rclcpp::Time lastPubTime_{0};
   rclcpp::Subscription<EventArray>::SharedPtr eventSub_;

--- a/launch/frequency_cam.launch.py
+++ b/launch/frequency_cam.launch.py
@@ -35,7 +35,6 @@ def launch_setup(context, *args, **kwargs):
         # prefix=['valgrind --tool=callgrind --dump-instr=yes
         #  --simulate-cache=yes --collect-jumps=yes'],
         # prefix=['xterm -e gdb -ex run --args'],
-        # prefix=['gdb -ex run --args'],
         name='frequency_cam',
         parameters=[
             {'use_sim_time': LaunchConfig('use_sim_time'),
@@ -46,18 +45,15 @@ def launch_setup(context, *args, **kwargs):
              'debug_y': 194,
              'use_log_frequency': False,
              'overlay_events': True,
-             #'bag_file': LaunchConfig('bag').perform(context),
-             'bag_file': '2023-05-10_wand_0-dvs1',
-             'trigger_file': '2023-05-10_wand_0_triggers.txt',
+             'bag_file': LaunchConfig('bag').perform(context),
              'use_external_triggers': True,
              'max_time_difference_us_to_trigger': 1000,
-             # 'trigger_file': 'triggers.txt',
+             'trigger_file': 'triggers.txt',
              'publishing_frequency': 25.0}],
         remappings=[
             ('~/events', event_topic),
             ('~/image', image_topic)
-        ]#,
-        #prefix=['gdb -ex run --args']
+        ]
     )
     return [node]
 

--- a/launch/frequency_cam.launch.py
+++ b/launch/frequency_cam.launch.py
@@ -49,6 +49,8 @@ def launch_setup(context, *args, **kwargs):
              #'bag_file': LaunchConfig('bag').perform(context),
              'bag_file': '2023-05-10_wand_0-dvs1',
              'trigger_file': '2023-05-10_wand_0_triggers.txt',
+             'use_external_triggers': True,
+             'max_time_difference_us_to_trigger': 1000,
              # 'trigger_file': 'triggers.txt',
              'publishing_frequency': 25.0}],
         remappings=[

--- a/launch/frequency_cam.launch.py
+++ b/launch/frequency_cam.launch.py
@@ -45,12 +45,16 @@ def launch_setup(context, *args, **kwargs):
              'debug_y': 194,
              'use_log_frequency': False,
              'overlay_events': True,
-             'bag_file': LaunchConfig('bag').perform(context),
+             #'bag_file': LaunchConfig('bag').perform(context),
+             'bag_file': '2023-03-08-wand_1-dvs2',
+             'trigger_file': 'triggers.txt',
              'publishing_frequency': 25.0}],
         remappings=[
             ('~/events', event_topic),
             ('~/image', image_topic)
-        ])
+        ]#,
+        #prefix=['gdb -ex run --args']
+    )
     return [node]
 
 

--- a/launch/frequency_cam.launch.py
+++ b/launch/frequency_cam.launch.py
@@ -35,6 +35,7 @@ def launch_setup(context, *args, **kwargs):
         # prefix=['valgrind --tool=callgrind --dump-instr=yes
         #  --simulate-cache=yes --collect-jumps=yes'],
         # prefix=['xterm -e gdb -ex run --args'],
+        # prefix=['gdb -ex run --args'],
         name='frequency_cam',
         parameters=[
             {'use_sim_time': LaunchConfig('use_sim_time'),
@@ -46,8 +47,9 @@ def launch_setup(context, *args, **kwargs):
              'use_log_frequency': False,
              'overlay_events': True,
              #'bag_file': LaunchConfig('bag').perform(context),
-             'bag_file': '2023-03-08-wand_1-dvs2',
-             'trigger_file': 'triggers.txt',
+             'bag_file': '2023-05-10_wand_0-dvs1',
+             'trigger_file': '2023-05-10_wand_0_triggers.txt',
+             # 'trigger_file': 'triggers.txt',
              'publishing_frequency': 25.0}],
         remappings=[
             ('~/events', event_topic),

--- a/src/frequency_cam.cpp
+++ b/src/frequency_cam.cpp
@@ -177,7 +177,7 @@ std::optional<std::vector<cv::Mat>> FrequencyCam::makeFrequencyAndEventImage(
       distance_too_big = true;
     }
     // We are using the received trigger time stamps
-    else {
+    else if (hasValidTime_) {
       // Get the smallest difference
       auto it = std::min_element(
         eventTimesNs_.begin(), eventTimesNs_.end(),
@@ -214,6 +214,20 @@ std::optional<std::vector<cv::Mat>> FrequencyCam::makeFrequencyAndEventImage(
       } else {
         distance_too_big = true;
       }
+    } else {
+      if (overlayEvents) {
+        *evImg = cv::Mat::zeros(height_, width_, CV_8UC1);
+      }
+      if (useLogFrequency) {
+        result.emplace_back(
+          overlayEvents ? makeTransformedFrequencyImage<LogTF, EventFrameUpdater>(evImg, dt)
+                        : makeTransformedFrequencyImage<LogTF, NoEventFrameUpdater>(evImg, dt));
+      } else {
+        result.emplace_back(
+          overlayEvents ? makeTransformedFrequencyImage<NoTF, EventFrameUpdater>(evImg, dt)
+                        : makeTransformedFrequencyImage<NoTF, NoEventFrameUpdater>(evImg, dt));
+      }
+      distance_too_big = true;
     }
     iteration++;
   }

--- a/src/frequency_cam.cpp
+++ b/src/frequency_cam.cpp
@@ -38,7 +38,10 @@ int roundUp(const int numToRound, const int multiple)
     return numToRound + multiple - remainder;
 }
 
-FrequencyCam::~FrequencyCam() { delete[] state_; }
+FrequencyCam::~FrequencyCam() {
+  csv_file_.close();
+  delete[] state_;
+}
 
 static void compute_alpha_beta(const double T_cut, double * alpha, double * beta)
 {

--- a/src/frequency_cam.cpp
+++ b/src/frequency_cam.cpp
@@ -27,9 +27,6 @@ namespace frequency_cam
 FrequencyCam::~FrequencyCam()
 {
   delete[] state_;
-
-  std::cout << "Number of external triggers: " << nrExtTriggers_ << std::endl;
-  std::cout << "Number of time synchronization matches: " << nrSyncMatches_ << std::endl;
 }
 
 static void compute_alpha_beta(const double T_cut, double * alpha, double * beta)
@@ -245,6 +242,10 @@ std::optional<std::vector<cv::Mat>> FrequencyCam::makeFrequencyAndEventImage(
 void FrequencyCam::getStatistics(size_t * numEvents) const { *numEvents = eventCount_; }
 
 void FrequencyCam::resetStatistics() { eventCount_ = 0; }
+
+void FrequencyCam::getNrExternalTriggers(size_t * nrExternalTriggers) const { *nrExternalTriggers = nrExtTriggers_; }
+
+void FrequencyCam::getNrSyncMatches(size_t * nrSyncMatches) const { *nrSyncMatches = nrSyncMatches_; }
 
 void FrequencyCam::setTriggers(const std::string & triggers_file)
 {

--- a/src/frequency_cam.cpp
+++ b/src/frequency_cam.cpp
@@ -24,21 +24,8 @@
 namespace frequency_cam
 {
 
-int roundUp(const int numToRound, const int multiple)
+FrequencyCam::~FrequencyCam()
 {
-    if (multiple == 0) {
-      return numToRound;
-    }
-
-    int remainder = numToRound % multiple;
-    if (remainder == 0) {
-      return numToRound;
-    }
-
-    return numToRound + multiple - remainder;
-}
-
-FrequencyCam::~FrequencyCam() {
   delete[] state_;
 
   std::cout << "Number of external triggers: " << nrExtTriggers_ << std::endl;
@@ -120,8 +107,9 @@ std::optional<std::vector<cv::Mat>> FrequencyCam::makeFrequencyAndEventImage(
   // contains events corresponding to multiiple trigger time stamps. Therefore,
   // we loop until the temporal distance gets too big.
   std::size_t iteration = 0;
-  while (!distance_too_big && ((use_external_triggers_ && (hasValidTime_ || !externalTriggers_.empty())) ||
-                                !use_external_triggers_)) { 
+  while (!distance_too_big &&
+         ((use_external_triggers_ && (hasValidTime_ || !externalTriggers_.empty())) ||
+          !use_external_triggers_)) {
     uint64_t difference = 1e9;
 
     std::vector<uint64_t>::iterator it = eventTimesNs_.end();
@@ -130,13 +118,16 @@ std::optional<std::vector<cv::Mat>> FrequencyCam::makeFrequencyAndEventImage(
     // We are using the external trigger txt file as source for the trigger time stamps
     if (!externalTriggers_.empty()) {
       // We go through all the trigger time stamps (unless the distance gets too high)
-      for (auto trigger_it = externalTriggers_.begin(); trigger_it != externalTriggers_.end(); trigger_it++) {
+      for (auto trigger_it = externalTriggers_.begin(); trigger_it != externalTriggers_.end();
+           trigger_it++) {
         // Get the closest time stamp of the events
-        it = std::min_element(eventTimesNs_.begin(), eventTimesNs_.end(), [&value = *trigger_it] (uint64_t a, uint64_t b) {
-              uint64_t diff_a =  (a > value) ? a - value : value - a;
-              uint64_t diff_b = (value > b) ? value - b : b - value;
-              return diff_a < diff_b;
-        });
+        it = std::min_element(
+          eventTimesNs_.begin(), eventTimesNs_.end(),
+          [&value = *trigger_it](uint64_t a, uint64_t b) {
+            uint64_t diff_a = (a > value) ? a - value : value - a;
+            uint64_t diff_b = (value > b) ? value - b : b - value;
+            return diff_a < diff_b;
+          });
         if (it != eventTimesNs_.end()) {
           difference = (*it > *trigger_it) ? *it - *trigger_it : *trigger_it - *it;
 
@@ -152,12 +143,14 @@ std::optional<std::vector<cv::Mat>> FrequencyCam::makeFrequencyAndEventImage(
             }
             if (useLogFrequency) {
               result.emplace_back(
-                overlayEvents ? makeTransformedFrequencyImage<LogTF, EventFrameUpdater>(evImg, dt)
-                              : makeTransformedFrequencyImage<LogTF, NoEventFrameUpdater>(evImg, dt));
+                overlayEvents
+                  ? makeTransformedFrequencyImage<LogTF, EventFrameUpdater>(evImg, dt)
+                  : makeTransformedFrequencyImage<LogTF, NoEventFrameUpdater>(evImg, dt));
             } else {
-            result.emplace_back(
-              overlayEvents ? makeTransformedFrequencyImage<NoTF, EventFrameUpdater>(evImg, dt)
-                            : makeTransformedFrequencyImage<NoTF, NoEventFrameUpdater>(evImg, dt));
+              result.emplace_back(
+                overlayEvents
+                  ? makeTransformedFrequencyImage<NoTF, EventFrameUpdater>(evImg, dt)
+                  : makeTransformedFrequencyImage<NoTF, NoEventFrameUpdater>(evImg, dt));
             }
           }
 
@@ -170,32 +163,37 @@ std::optional<std::vector<cv::Mat>> FrequencyCam::makeFrequencyAndEventImage(
           }
         }
       }
-      // We remove the trigger time stamps for which we found a corresponding event time stamp 
+      // We remove the trigger time stamps for which we found a corresponding event time stamp
       for (auto it : iterators_to_remove) {
         if (it != externalTriggers_.end()) {
           *it = 0;
         }
       }
-      externalTriggers_.erase(remove(externalTriggers_.begin(), externalTriggers_.end(), 0), externalTriggers_.end() );
+      externalTriggers_.erase(
+        remove(externalTriggers_.begin(), externalTriggers_.end(), 0), externalTriggers_.end());
       iterators_to_remove.clear();
-      
+
       // If we have gone through all the trigger time stamps or stopped, we stop the while loop
       distance_too_big = true;
     }
     // We are using the received trigger time stamps
     else {
       // Get the smallest difference
-      auto it = std::min_element(eventTimesNs_.begin(), eventTimesNs_.end(), [&value = sensor_time_] (uint64_t a, uint64_t b) {
-            uint64_t diff_a =  (a > value) ? a - value : value - a;
-            uint64_t diff_b = (value > b) ? value - b : b - value;
-            return diff_a < diff_b;
-      });
+      auto it = std::min_element(
+        eventTimesNs_.begin(), eventTimesNs_.end(),
+        [&value = sensor_time_](uint64_t a, uint64_t b) {
+          uint64_t diff_a = (a > value) ? a - value : value - a;
+          uint64_t diff_b = (value > b) ? value - b : b - value;
+          return diff_a < diff_b;
+        });
       if (it != eventTimesNs_.end()) {
         difference = (*it > sensor_time_) ? *it - sensor_time_ : sensor_time_ - *it;
       }
 
       if (difference /*ns*/ < max_time_difference_us_to_trigger_ * 1e3) {
-        if (!hasValidTime_ && !externalTriggers_.empty() && iterator_to_remove != externalTriggers_.end()) {
+        if (
+          !hasValidTime_ && !externalTriggers_.empty() &&
+          iterator_to_remove != externalTriggers_.end()) {
           externalTriggers_.erase(iterator_to_remove);
         }
         hasValidTime_ = false;
@@ -234,20 +232,20 @@ void FrequencyCam::getStatistics(size_t * numEvents) const { *numEvents = eventC
 
 void FrequencyCam::resetStatistics() { eventCount_ = 0; }
 
-void FrequencyCam::setTriggers(const std::string & triggers_file) {
+void FrequencyCam::setTriggers(const std::string & triggers_file)
+{
   std::string line;
   std::ifstream myfile;
   myfile.open(triggers_file);
 
-  if(!myfile.is_open()) {
+  if (!myfile.is_open()) {
     std::cerr << "Error open" << std::endl;
   }
 
-  while(getline(myfile, line)) {
+  while (getline(myfile, line)) {
     uint64_t time_stamp = std::stoi(line);
     externalTriggers_.emplace_back(time_stamp * 1000);
   }
-
 }
 
 std::ostream & operator<<(std::ostream & os, const FrequencyCam::Event & e)

--- a/src/frequency_cam.cpp
+++ b/src/frequency_cam.cpp
@@ -23,6 +23,21 @@
 
 namespace frequency_cam
 {
+
+int roundUp(const int numToRound, const int multiple)
+{
+    if (multiple == 0) {
+      return numToRound;
+    }
+
+    int remainder = numToRound % multiple;
+    if (remainder == 0) {
+      return numToRound;
+    }
+
+    return numToRound + multiple - remainder;
+}
+
 FrequencyCam::~FrequencyCam() { delete[] state_; }
 
 static void compute_alpha_beta(const double T_cut, double * alpha, double * beta)

--- a/src/frequency_cam.cpp
+++ b/src/frequency_cam.cpp
@@ -175,12 +175,12 @@ std::optional<cv::Mat> FrequencyCam::makeFrequencyAndEventImage(
       }
       if (useLogFrequency) {
         return (
-          overlayEvents ? makeTransformedFrequencyImage<LogTF, EventFrameUpdater>(evImg, dt)
-                        : makeTransformedFrequencyImage<LogTF, NoEventFrameUpdater>(evImg, dt));
+          overlayEvents ? makeTransformedFrequencyImage<LogTF, EventFrameUpdater>(evImg, dt, trigger_time)
+                        : makeTransformedFrequencyImage<LogTF, NoEventFrameUpdater>(evImg, dt, trigger_time));
       }
       return (
-        overlayEvents ? makeTransformedFrequencyImage<NoTF, EventFrameUpdater>(evImg, dt)
-                      : makeTransformedFrequencyImage<NoTF, NoEventFrameUpdater>(evImg, dt));
+        overlayEvents ? makeTransformedFrequencyImage<NoTF, EventFrameUpdater>(evImg, dt, trigger_time)
+                      : makeTransformedFrequencyImage<NoTF, NoEventFrameUpdater>(evImg, dt, trigger_time));
     }
   }
   return {};

--- a/src/frequency_cam.cpp
+++ b/src/frequency_cam.cpp
@@ -69,8 +69,8 @@ bool FrequencyCam::initialize(
   debugX_ = debugX;
   debugY_ = debugY;
 
-  use_external_triggers_ = use_external_triggers;
-  max_time_difference_us_to_trigger_ = max_time_difference_us_to_trigger;
+  useExternalTriggers_ = use_external_triggers;
+  maxTimeDifferenceUsToTrigger_ = max_time_difference_us_to_trigger;
 
   return (true);
 }
@@ -108,8 +108,8 @@ std::optional<std::vector<cv::Mat>> FrequencyCam::makeFrequencyAndEventImage(
   // we loop until the temporal distance gets too big.
   std::size_t iteration = 0;
   while (!distance_too_big &&
-         ((use_external_triggers_ && (hasValidTime_ || !externalTriggers_.empty())) ||
-          !use_external_triggers_)) {
+         ((useExternalTriggers_ && (hasValidTime_ || !externalTriggers_.empty())) ||
+          !useExternalTriggers_)) {
     uint64_t difference = 1e9;
 
     std::vector<uint64_t>::iterator it = eventTimesNs_.end();
@@ -131,7 +131,7 @@ std::optional<std::vector<cv::Mat>> FrequencyCam::makeFrequencyAndEventImage(
         if (it != eventTimesNs_.end()) {
           difference = (*it > *trigger_it) ? *it - *trigger_it : *trigger_it - *it;
 
-          if (difference /*ns*/ < max_time_difference_us_to_trigger_ * 1e3) {
+          if (difference /*ns*/ < maxTimeDifferenceUsToTrigger_ * 1e3) {
             iterator_to_remove = trigger_it;
             iterators_to_remove.emplace_back(iterator_to_remove);
 
@@ -190,7 +190,7 @@ std::optional<std::vector<cv::Mat>> FrequencyCam::makeFrequencyAndEventImage(
         difference = (*it > sensor_time_) ? *it - sensor_time_ : sensor_time_ - *it;
       }
 
-      if (difference /*ns*/ < max_time_difference_us_to_trigger_ * 1e3) {
+      if (difference /*ns*/ < maxTimeDifferenceUsToTrigger_ * 1e3) {
         if (
           !hasValidTime_ && !externalTriggers_.empty() &&
           iterator_to_remove != externalTriggers_.end()) {

--- a/src/frequency_cam.cpp
+++ b/src/frequency_cam.cpp
@@ -105,7 +105,7 @@ void FrequencyCam::initializeState(uint32_t width, uint32_t height, uint64_t t_f
 }
 
 cv::Mat FrequencyCam::makeFrequencyAndEventImage(
-  cv::Mat * evImg, bool overlayEvents, bool useLogFrequency, float dt) const
+  cv::Mat * evImg, bool overlayEvents, bool useLogFrequency, float dt)
 {
   if (overlayEvents) {
     *evImg = cv::Mat::zeros(height_, width_, CV_8UC1);

--- a/src/frequency_cam_ros2.cpp
+++ b/src/frequency_cam_ros2.cpp
@@ -174,7 +174,13 @@ void FrequencyCamROS::playEventsFromBag(
   // event count
   size_t numEvents;
   cam_.getStatistics(&numEvents);
+  size_t nrExternalTriggers;
+  cam_.getNrExternalTriggers(&nrExternalTriggers);
+  size_t nrSyncMatches;
+  cam_.getNrSyncMatches(&nrSyncMatches);
   RCLCPP_INFO_STREAM(get_logger(), "played bag at rate: " << (numEvents / totTime_) << " Mev/s");
+  RCLCPP_INFO_STREAM(get_logger(), "Number of external triggers: " << nrExternalTriggers);
+  RCLCPP_INFO_STREAM(get_logger(), "Number of time synchronization matches: " << nrSyncMatches);
   rclcpp::shutdown();
 }
 

--- a/src/frequency_cam_ros2.cpp
+++ b/src/frequency_cam_ros2.cpp
@@ -71,12 +71,17 @@ bool FrequencyCamROS::initialize()
     declare_parameter<std::vector<double>>("legend_frequencies", std::vector<double>()));
   imageMaker_.setLegendNumBins(declare_parameter<int>("legend_num_bins", 11));
   imageMaker_.setNumSigDigits(declare_parameter<int>("legend_num_sig_digits", 3));
-  bool use_external_triggers = static_cast<bool>(declare_parameter<bool>("use_external_triggers", false));
-  uint64_t max_time_difference_us_to_trigger = static_cast<uint64_t>(declare_parameter<int64>("max_time_difference_us_to_trigger", 1000));
+  bool use_external_triggers =
+    static_cast<bool>(declare_parameter<bool>("use_external_triggers", false));
+  std::cout << "use_external_triggers: " << use_external_triggers << std::endl;
+  uint64_t max_time_difference_us_to_trigger =
+    static_cast<uint64_t>(declare_parameter<int64>("max_time_difference_us_to_trigger", 1000));
+  std::cout << "max_time_difference_us_to_trigger: " << max_time_difference_us_to_trigger
+            << std::endl;
   cam_.initialize(
     minFreq, maxFreq, declare_parameter<double>("cutoff_period", 5.0),
-    declare_parameter<int>("num_timeout_cycles", 2.0), debugX_, debugY_,
-    use_external_triggers, max_time_difference_us_to_trigger);
+    declare_parameter<int>("num_timeout_cycles", 2.0), debugX_, debugY_, use_external_triggers,
+    max_time_difference_us_to_trigger);
 
   const std::string bag = this->declare_parameter<std::string>("bag_file", "");
   const std::string trigger_file = this->declare_parameter<std::string>("trigger_file", "");
@@ -97,12 +102,14 @@ bool FrequencyCamROS::initialize()
       "~/events", qos, std::bind(&FrequencyCamROS::eventMsg, this, std::placeholders::_1));
   } else {
     // reading from bag is only for debugging
-    playEventsFromBag(bag, declare_parameter<std::string>("bag_topic", "/event_camera/events"), trigger_file);
+    playEventsFromBag(
+      bag, declare_parameter<std::string>("bag_topic", "/event_camera/events"), trigger_file);
   }
   return (true);
 }
 
-void FrequencyCamROS::playEventsFromBag(const std::string & bagName, const std::string & bagTopic, const std::string & trigger_file)
+void FrequencyCamROS::playEventsFromBag(
+  const std::string & bagName, const std::string & bagTopic, const std::string & trigger_file)
 {
   imageMaker_.setScale(this->declare_parameter<double>("scale_image", 1.0));
   rclcpp::Time lastFrameTime(0);
@@ -130,20 +137,21 @@ void FrequencyCamROS::playEventsFromBag(const std::string & bagName, const std::
     if (msg) {
       // const rclcpp::Time t(msg->header.stamp);
       eventMsg(msg);
-        // if (t - lastFrameTime > delta_t) {
-        cv::Mat eventImg;
-        if (auto freqImg = cam_.makeFrequencyAndEventImage(
+      // if (t - lastFrameTime > delta_t) {
+      cv::Mat eventImg;
+      if (
+        auto freqImg = cam_.makeFrequencyAndEventImage(
           &eventImg, overlayEvents_, useLogFrequency_, eventImageDt_)) {
-          for (const auto& img : *freqImg) {
-            const cv::Mat window =
-              imageMaker_.make((lastFrameTime + delta_t).nanoseconds(), img, eventImg);
-            lastFrameTime = lastFrameTime + delta_t;
-            char fname[256];
-            snprintf(fname, sizeof(fname) - 1, "/frame_%05u.jpg", frameCount);
-            cv::imwrite(path + fname, window);
-            frameCount++;
-          }
+        for (const auto & img : *freqImg) {
+          const cv::Mat window =
+            imageMaker_.make((lastFrameTime + delta_t).nanoseconds(), img, eventImg);
+          lastFrameTime = lastFrameTime + delta_t;
+          char fname[256];
+          snprintf(fname, sizeof(fname) - 1, "/frame_%05u.jpg", frameCount);
+          cv::imwrite(path + fname, window);
+          frameCount++;
         }
+      }
       // }
       // }
       // else {
@@ -200,9 +208,10 @@ void FrequencyCamROS::frameTimerExpired()
 {
   if (imagePub_.getNumSubscribers() != 0 && height_ != 0) {
     cv::Mat eventImg;
-    if (auto freqImg =
-      cam_.makeFrequencyAndEventImage(&eventImg, overlayEvents_, useLogFrequency_, eventImageDt_)) {
-      for (const auto& img : *freqImg) {
+    if (
+      auto freqImg = cam_.makeFrequencyAndEventImage(
+        &eventImg, overlayEvents_, useLogFrequency_, eventImageDt_)) {
+      for (const auto & img : *freqImg) {
         const cv::Mat window =
           imageMaker_.make(this->get_clock()->now().nanoseconds(), img, eventImg);
         imagePub_.publish(cv_bridge::CvImage(header_, "bgr8", window).toImageMsg());

--- a/src/frequency_cam_ros2.cpp
+++ b/src/frequency_cam_ros2.cpp
@@ -71,16 +71,13 @@ bool FrequencyCamROS::initialize()
     declare_parameter<std::vector<double>>("legend_frequencies", std::vector<double>()));
   imageMaker_.setLegendNumBins(declare_parameter<int>("legend_num_bins", 11));
   imageMaker_.setNumSigDigits(declare_parameter<int>("legend_num_sig_digits", 3));
-  bool use_external_triggers =
+  use_external_triggers_ =
     static_cast<bool>(declare_parameter<bool>("use_external_triggers", false));
-  std::cout << "use_external_triggers: " << use_external_triggers << std::endl;
   uint64_t max_time_difference_us_to_trigger =
     static_cast<uint64_t>(declare_parameter<int64>("max_time_difference_us_to_trigger", 1000));
-  std::cout << "max_time_difference_us_to_trigger: " << max_time_difference_us_to_trigger
-            << std::endl;
   cam_.initialize(
     minFreq, maxFreq, declare_parameter<double>("cutoff_period", 5.0),
-    declare_parameter<int>("num_timeout_cycles", 2.0), debugX_, debugY_, use_external_triggers,
+    declare_parameter<int>("num_timeout_cycles", 2.0), debugX_, debugY_, use_external_triggers_,
     max_time_difference_us_to_trigger);
 
   const std::string bag = this->declare_parameter<std::string>("bag_file", "");


### PR DESCRIPTION
This PR adds the functionality to:
* Output frames for time stamps where an external trigger occurred
* Supports trigger events in the encoded data
* Supports triggers extracted with [this script](https://github.com/AndreasAZiegler/e2calib/blob/main/python/extract_triggers_prophesee.py).
* Allows to set the maximal time difference between the trigger time stamp and event time stamps.