### PR TITLE
fixes rosbag storage_id and EventCDConverter import

### DIFF
--- a/src/mv_vs_frequency_cam.py
+++ b/src/mv_vs_frequency_cam.py
@@ -24,7 +24,7 @@ import cv2  # noqa: I100
 import frequency_cam  # noqa: I100
 import numpy as np
 from metavision_sdk_analytics import FrequencyMapAsyncAlgorithm  # noqa: I100
-from read_bag_ros2 import read_bag
+from read_bag_ros2 import read_bag, EventCDConverter
 
 # global variables to keep track of current frame, events etc
 
@@ -301,7 +301,7 @@ if __name__ == '__main__':
     labels = args.labels
 
     events, res, offset, _, _ = read_bag(
-        args.bag, args.topic, use_sensor_time=False, converter=frequency_cam.EventCDConverter()
+        args.bag, args.topic, use_sensor_time=False, converter=EventCDConverter()
     )
 
     Path(args.output_dir).mkdir(parents=True, exist_ok=True)

--- a/src/read_bag_ros2.py
+++ b/src/read_bag_ros2.py
@@ -55,7 +55,7 @@ class BagReader:
         return (topic, msg, t_rec)
 
     def get_rosbag_options(self, path, serialization_format='cdr'):
-        storage_options = rosbag2_py.StorageOptions(uri=path, storage_id='sqlite3')
+        storage_options = rosbag2_py.StorageOptions(uri=path, storage_id='mcap')
         converter_options = rosbag2_py.ConverterOptions(
             input_serialization_format=serialization_format,
             output_serialization_format=serialization_format,


### PR DESCRIPTION
### Changes
1. Since the recommended tool to create `bag` files from `raw` files ([event_camera_tools](https://github.com/ros-event-camera/event_camera_tools)) generate `mcap` files by default, `storage_id` in [read_bag_ros2.py](https://github.com/berndpfrommer/frequency_cam/blob/be3060a744449612a64b5dedf4f8335dd555edcc/src/read_bag_ros2.py#L58) file was changed from `sqlite3` to `mcap` to avoid the following error when running `src/mv_vs_frequency_cam.py` file with defined `--bag:`
```
[ERROR] [1717085906.299389849] [rosbag2_storage]: Could not open '/mnt/d/_FEL/CMP/event_cam_experiments/event_cam_experiments/experiments/02_drill_slow_longer/drill_slow_bag/drill_slow_bag_0.mcap' with 'sqlite3'. Error: Failed to setup storage. Error: Error when processing SQL statement. SQLite error (26): fi
le is not a database
[ERROR] [1717085906.299537250] [rosbag2_storage]: Could not load/open plugin with storage id 'sqlite3'
Traceback (most recent call last):
  File "/mnt/d/_FEL/CMP/event_cam_experiments/event_cam_experiments/frequency_cam/src/mv_vs_frequency_cam.py", line 264, in <module>
    events, res, offset, _, _ = read_bag(
  File "/mnt/d/_FEL/CMP/event_cam_experiments/event_cam_experiments/frequency_cam/src/read_bag_ros2.py", line 117, in read_bag
    bag = BagReader(bag_path, topic)
  File "/mnt/d/_FEL/CMP/event_cam_experiments/event_cam_experiments/frequency_cam/src/read_bag_ros2.py", line 39, in __init__
    self.reader.open(storage_options, converter_options)
RuntimeError: No storage could be initialized. Abort
```

2. `EventCDConverter` is not defined in `frequency_cam.py` file as used on line [304 in file src/mv_vs_frequency_cam.py](https://github.com/berndpfrommer/frequency_cam/blob/be3060a744449612a64b5dedf4f8335dd555edcc/src/mv_vs_frequency_cam.py#L304). To mitigate this error, `EventCDConverter` is imported from `read_bag_ros2` as it was before the last commit.

### Additional help required
After these two mentioned fixed, the `mv_vs_frequency_cam.py` starts without any errors or warnings. However, it produces a `Seg fault` at line [343 in file mv_vs_frequency_cam.py](https://github.com/berndpfrommer/frequency_cam/blob/be3060a744449612a64b5dedf4f8335dd555edcc/src/mv_vs_frequency_cam.py#L343): `mv_algo.process_events(evs)`. With this line commented out, the seg fault does not occur. Here is the full console output:

```
DESKTOP:~$/usr/bin/python3 ./src/mv_vs_frequency_cam.py --bag ./bag/
took 0.326548s to process 118, rate: 361.35538384819984 msgs/s, 6.73576234961081 Mev/s
Segmentation fault
```